### PR TITLE
Refactor

### DIFF
--- a/oUF_Experience.lua
+++ b/oUF_Experience.lua
@@ -45,10 +45,11 @@ local function GetValues()
 end
 
 local function UpdateTooltip(element)
-	local cur, max, perc, bars, _, restedPerc = GetValues()
+	local cur, max, perc, _, rested, restedPerc, _, _, isHonor = GetValues()
 
-	GameTooltip:SetText(format('%s / %s (%d%%)', BreakUpLargeNumbers(cur), BreakUpLargeNumbers(max), perc), 1, 1, 1)
-	GameTooltip:AddLine(format('%.1f bars, %d%% rested', bars, restedPerc))
+	GameTooltip:SetText(isHonor and HONOR or COMBAT_XP_GAIN)
+	GameTooltip:AddLine(format('%s / %s (%d%%)', BreakUpLargeNumbers(cur), BreakUpLargeNumbers(max), perc), 1, 1, 1)
+	GameTooltip:AddLine(format('%s: %s (%d%%)', TUTORIAL_TITLE26, BreakUpLargeNumbers(rested), restedPerc), 1, 1, 1)
 	GameTooltip:Show()
 end
 

--- a/oUF_Experience.lua
+++ b/oUF_Experience.lua
@@ -47,7 +47,11 @@ local function UpdateTooltip(element)
 
 	GameTooltip:SetText(isHonor and HONOR or COMBAT_XP_GAIN)
 	GameTooltip:AddLine(format('%s / %s (%d%%)', BreakUpLargeNumbers(cur), BreakUpLargeNumbers(max), perc), 1, 1, 1)
-	GameTooltip:AddLine(format('%s: %s (%d%%)', TUTORIAL_TITLE26, BreakUpLargeNumbers(rested), restedPerc), 1, 1, 1)
+
+	if(rested > 0) then
+		GameTooltip:AddLine(format('%s: %s (%d%%)', TUTORIAL_TITLE26, BreakUpLargeNumbers(rested), restedPerc), 1, 1, 1)
+	end
+
 	GameTooltip:Show()
 end
 

--- a/oUF_Experience.lua
+++ b/oUF_Experience.lua
@@ -66,26 +66,27 @@ local function OnLeave(element)
 	element:SetAlpha(element.outAlpha)
 end
 
-local function UpdateColor(element, showHonor, isRested)
-	if(showHonor) then
-		element:SetStatusBarColor(1, 1/4, 0)
-		if(element.SetAnimatedTextureColors) then
-			element:SetAnimatedTextureColors(1, 1/4, 0)
-		end
-
-		if(element.Rested) then
-			element.Rested:SetStatusBarColor(1, 3/4, 0)
+local function UpdateColor(element, isHonor, isRested)
+	local r, g, b
+	if (isHonor) then
+		if (isRested) then
+			r, g, b = 1, 0.71, 0
+		else
+			r, g, b = 1, 0.24, 0
 		end
 	else
-		element:SetStatusBarColor(1/6, 2/3, 1/5)
-		if(element.SetAnimatedTextureColors) then
-			element:SetAnimatedTextureColors(1/6, 2/3, 1/5)
-		end
-
-		if(element.Rested) then
-			element.Rested:SetStatusBarColor(0, 2/5, 1)
+		if (isRested) then
+			r, g, b = 0, 0.39, 0.88
+		else
+			r, g, b = 0.58, 0, 0.55
 		end
 	end
+
+	element:SetStatusBarColor(r, g, b)
+	if(element.SetAnimatedTextureColors) then
+		element:SetAnimatedTextureColors(r, g, b)
+	end
+	element.Rested:SetStatusBarColor(r, g, b, 0.25)
 end
 
 local function Update(self, event, unit)

--- a/oUF_Experience.lua
+++ b/oUF_Experience.lua
@@ -86,7 +86,7 @@ local function UpdateColor(element, isHonor, isRested)
 	if(element.SetAnimatedTextureColors) then
 		element:SetAnimatedTextureColors(r, g, b)
 	end
-	element.Rested:SetStatusBarColor(r, g, b, 0.25)
+	element.Rested:SetStatusBarColor(r, g, b, element.restedAlpha)
 end
 
 local function Update(self, event, unit)
@@ -194,6 +194,7 @@ local function Enable(self, unit)
 		end
 
 		element.ForceUpdate = ForceUpdate
+		element.restedAlpha = element.restedAlpha or 0.15
 
 		self:RegisterEvent('PLAYER_LEVEL_UP', VisibilityPath, true)
 		self:RegisterEvent('HONOR_LEVEL_UPDATE', VisibilityPath)

--- a/oUF_Experience.lua
+++ b/oUF_Experience.lua
@@ -48,7 +48,7 @@ local function UpdateTooltip(element)
 	local cur, max, perc, bars, _, restedPerc = GetValues()
 
 	GameTooltip:SetText(format('%s / %s (%d%%)', BreakUpLargeNumbers(cur), BreakUpLargeNumbers(max), perc), 1, 1, 1)
-	GameTooltip:AddLine(format('%.1f bars, %d rested', bars, restedPerc))
+	GameTooltip:AddLine(format('%.1f bars, %d%% rested', bars, restedPerc))
 	GameTooltip:Show()
 end
 

--- a/oUF_Experience.lua
+++ b/oUF_Experience.lua
@@ -66,7 +66,7 @@ local function OnLeave(element)
 	element:SetAlpha(element.outAlpha)
 end
 
-local function UpdateColor(element, showHonor)
+local function UpdateColor(element, showHonor, isRested)
 	if(showHonor) then
 		element:SetStatusBarColor(1, 1/4, 0)
 		if(element.SetAnimatedTextureColors) then
@@ -112,7 +112,7 @@ local function Update(self, event, unit)
 		element.Rested:SetValue(math.min(cur + rested, max))
 	end
 
-	(element.OverrideUpdateColor or UpdateColor)(element, isHonor)
+	(element.OverrideUpdateColor or UpdateColor)(element, isHonor, rested > 0)
 
 	if(element.PostUpdate) then
 		return element:PostUpdate(unit, cur, max, rested, level, isHonor)

--- a/oUF_Experience.lua
+++ b/oUF_Experience.lua
@@ -33,19 +33,17 @@ local function GetValues()
 	local cur = (isHonor and UnitHonor or UnitXP)('player')
 	local max = (isHonor and UnitHonorMax or UnitXPMax)('player')
 	local perc = floor(cur / max * 100 + 0.5)
-	local bars = cur / max * (isHonor and 5 or 20)
 
 	local rested = (isHonor and GetHonorExhaustion or GetXPExhaustion)() or 0
 	local restedPerc = floor(rested / max * 100 + 0.5)
-	local barsRested = rested / max * (isHonor and 5 or 20)
 
 	local level = (isHonor and UnitHonorLevel or UnitLevel)('player')
 
-	return cur, max, perc, bars, rested, restedPerc, barsRested, level, isHonor
+	return cur, max, perc, rested, restedPerc, level, isHonor
 end
 
 local function UpdateTooltip(element)
-	local cur, max, perc, _, rested, restedPerc, _, _, isHonor = GetValues()
+	local cur, max, perc, rested, restedPerc, _, isHonor = GetValues()
 
 	GameTooltip:SetText(isHonor and HONOR or COMBAT_XP_GAIN)
 	GameTooltip:AddLine(format('%s / %s (%d%%)', BreakUpLargeNumbers(cur), BreakUpLargeNumbers(max), perc), 1, 1, 1)
@@ -92,7 +90,7 @@ local function Update(self, event, unit)
 	local element = self.Experience
 	if(element.PreUpdate) then element:PreUpdate(unit) end
 
-	local cur, max, perc, bars, rested, restedPerc, barsRested, level, isHonor = GetValues()
+	local cur, max, _, rested, _, level, isHonor = GetValues()
 
 	if(isHonor and level == GetMaxPlayerHonorLevel()) then
 		cur, max = 1, 1


### PR DESCRIPTION
Changes proposed in this pull request:
  - Reduce code duplication
  - Better tooltips (localized and with a title to tell users what they see)  
![experience](https://user-images.githubusercontent.com/363876/34955806-585c907e-fa26-11e7-972c-dd396d9154e7.jpg)
![honor](https://user-images.githubusercontent.com/363876/34955808-5bd53f08-fa26-11e7-8afa-57d751306d29.jpg)
  - Display rested text in tooltips if the player is actually rested
  - Drop the calculation of how many bars are filled (hard to localize and actually useless)
  - Mimic the default ui colors  
![experience colors](https://user-images.githubusercontent.com/363876/34957739-191eba46-fa2f-11e7-8cb6-993a9fd6c7a0.jpg)
![honor colors](https://user-images.githubusercontent.com/363876/34957741-1c2c68d2-fa2f-11e7-9a37-1dbba69fb173.jpg)  
The screenshots are with .restedAlpha of 0.5 (new element option to allow layout to override the default value of 0.15 which the stock ui uses), else the rested bar is hardly visible with my black bar background

The only issue with localization is that TUTORIAL_TITLE26 is not declined according to gender in laguages where that matters (checked Spanish and Russian), but still better than the fixed English word from before I think.
