### PR TITLE
outAlpha fix

### DIFF
--- a/oUF_Experience.lua
+++ b/oUF_Experience.lua
@@ -159,7 +159,7 @@ local function ElementEnable(self)
 	end
 
 	element:Show()
-	element:SetAlpha(element.outAlpha)
+	element:SetAlpha(element.outAlpha or 1)
 
 	Path(self, 'ElementEnable', 'player')
 end


### PR DESCRIPTION
element.outAlpha may be unsetted or not inited while element:IsMouseEnabled() == false, that handling error on attempting to call element:SetAlpha with nil param.

Fixes default element.outAlpha in ElementEnable function.

Changes proposed in this pull request:
- setting up default outAlpha while enabling element