### PR TITLE
Fix InActiveBattlefield

### DIFF
--- a/oUF_Experience.lua
+++ b/oUF_Experience.lua
@@ -105,7 +105,7 @@ local function IsPlayerMaxHonorLevel()
 end
 
 local function ShouldShowHonor()
-	return IsPlayerMaxLevel() and (IsWatchingHonorAsXP() or InActiveBattlefield() or IsInActiveWorldPVP())
+	return IsPlayerMaxLevel() and (IsWatchingHonorAsXP() or C_PvP.IsActiveBattlefield() or IsInActiveWorldPVP())
 end
 
 --[[ Tags:header


### PR DESCRIPTION
This was deprecated in 8.1.5 and removed in Shadowlands.
Compatible with retail.
